### PR TITLE
Workaround for "Frame load interupted"

### DIFF
--- a/TSMiniWebBrowser/TSMiniWebBrowser.m
+++ b/TSMiniWebBrowser/TSMiniWebBrowser.m
@@ -317,6 +317,22 @@
 
 #pragma mark - UIWebViewDelegate
 
+- (BOOL)webView:(UIWebView *)webView shouldStartLoadWithRequest:(NSURLRequest *)request navigationType:(UIWebViewNavigationType)navigationType {
+    if ([[request.URL absoluteString] hasPrefix:@"sms:"]) {
+        [[UIApplication sharedApplication] openURL:request.URL];
+        return NO;
+    }
+
+    if ([[request.URL absoluteString] hasPrefix:@"http://www.youtube.com/v/"] ||
+        [[request.URL absoluteString] hasPrefix:@"http://itunes.apple.com/"] ||
+        [[request.URL absoluteString] hasPrefix:@"http://phobos.apple.com/"]) {
+        [[UIApplication sharedApplication] openURL:request.URL];
+        return NO;
+    }
+    
+    return YES;
+}
+
 - (void)webViewDidStartLoad:(UIWebView *)webView {
     [self toggleBackForwardButtons];
 }


### PR DESCRIPTION
Did a quick fix for a common problem - some URLs which get redirected to built-in applications when using MobileSafari lead to an error "Frame load interupted" when you load them in UIWebView. Maybe you want to pull it.
