### PR TITLE
Ignore error alert when following links before a previous request has finished.

### DIFF
--- a/TSMiniWebBrowser/TSMiniWebBrowser.m
+++ b/TSMiniWebBrowser/TSMiniWebBrowser.m
@@ -412,6 +412,12 @@
 - (void)webView:(UIWebView *)webView didFailLoadWithError:(NSError *)error {
     [self hideActivityIndicators];
     
+    // To avoid getting an error alert when you click on a link
+    // before a request has finished loading.
+    if ([error code] == NSURLErrorCancelled) {
+        return;
+    }
+
     // Show error alert
     UIAlertView *alert = [[UIAlertView alloc] initWithTitle:NSLocalizedString(@"Could not load page", nil)
                                                     message:error.localizedDescription


### PR DESCRIPTION
If you follow a link and change your mind and follow another
link before the request for the first one is done, you get
a NSURLErrorDomain error -999.

This fix will ignore the error if the error code is equal
to NSURLErrorCancelled.
