### PR TITLE
Added domain lock list to force domains not in the list to load in Mobile Safari

### DIFF
--- a/TSMiniWebBrowser/TSMiniWebBrowser.h
+++ b/TSMiniWebBrowser/TSMiniWebBrowser.h
@@ -76,6 +76,7 @@ typedef enum {
 @property (nonatomic, assign) UIBarStyle barStyle;
 @property (nonatomic, strong) UIColor *barTintColor;
 @property (nonatomic, strong) NSString *modalDismissButtonTitle;
+@property (nonatomic, strong) NSString *domainLockList;
 
 // Public Methods
 - (id)initWithUrl:(NSURL*)url;

--- a/TSMiniWebBrowser/TSMiniWebBrowser.h
+++ b/TSMiniWebBrowser/TSMiniWebBrowser.h
@@ -77,6 +77,7 @@ typedef enum {
 @property (nonatomic, strong) UIColor *barTintColor;
 @property (nonatomic, strong) NSString *modalDismissButtonTitle;
 @property (nonatomic, strong) NSString *domainLockList;
+@property (nonatomic, strong) NSString *currentURL;
 
 // Public Methods
 - (id)initWithUrl:(NSURL*)url;

--- a/TSMiniWebBrowser/TSMiniWebBrowser.m
+++ b/TSMiniWebBrowser/TSMiniWebBrowser.m
@@ -37,6 +37,7 @@
 @synthesize barStyle;
 @synthesize modalDismissButtonTitle;
 @synthesize barTintColor;
+@synthesize domainLockList;
 
 #define kToolBarHeight  44
 #define kTabBarHeight   49
@@ -438,15 +439,50 @@ enum actionSheetButtonIndex {
         [[UIApplication sharedApplication] openURL:request.URL];
         return NO;
     }
-    
-    if ([[request.URL absoluteString] hasPrefix:@"http://www.youtube.com/v/"] ||
-        [[request.URL absoluteString] hasPrefix:@"http://itunes.apple.com/"] ||
-        [[request.URL absoluteString] hasPrefix:@"http://phobos.apple.com/"]) {
-        [[UIApplication sharedApplication] openURL:request.URL];
-        return NO;
-    }
-    
-    return YES;
+	
+	else
+	{
+		if ([[request.URL absoluteString] hasPrefix:@"http://www.youtube.com/v/"] ||
+			[[request.URL absoluteString] hasPrefix:@"http://itunes.apple.com/"] ||
+			[[request.URL absoluteString] hasPrefix:@"http://phobos.apple.com/"]) {
+			[[UIApplication sharedApplication] openURL:request.URL];
+			return NO;
+		}
+		
+		else
+		{
+            if (domainLockList == nil || [domainLockList isEqualToString:@""])
+            {
+                return YES;
+            }
+            
+            else
+            {
+                NSArray *domainList = [domainLockList componentsSeparatedByString:@","];
+                BOOL sendToSafari = YES;
+                
+                for (int x = 0; x < domainList.count; x++)
+                {
+                    if ([[request.URL absoluteString] hasPrefix:(NSString *)[domainList objectAtIndex:x]] == YES)
+                    {
+                        sendToSafari = NO;
+                    }
+                }
+
+                if (sendToSafari == YES)
+                {
+                    [[UIApplication sharedApplication] openURL:[request URL]];
+                    
+                    return NO;
+                }
+                
+                else
+                {
+                    return YES;
+                }
+            }
+		}
+	}
 }
 
 - (void)webViewDidStartLoad:(UIWebView *)webView {

--- a/TSMiniWebBrowser/TSMiniWebBrowser.m
+++ b/TSMiniWebBrowser/TSMiniWebBrowser.m
@@ -38,6 +38,7 @@
 @synthesize modalDismissButtonTitle;
 @synthesize barTintColor;
 @synthesize domainLockList;
+@synthesize currentURL;
 
 #define kToolBarHeight  44
 #define kTabBarHeight   49
@@ -159,7 +160,7 @@ enum actionSheetButtonIndex {
     [toolBarButtons addObject:buttonGoForward];
     [toolBarButtons addObject:flexibleSpace];
     [toolBarButtons addObject:buttonContainer];
-    if (showReloadButton) { 
+    if (showReloadButton) {
         [toolBarButtons addObject:buttonReload];
     }
     if (showActionButton) {
@@ -298,7 +299,7 @@ enum actionSheetButtonIndex {
         case UIInterfaceOrientationPortraitUpsideDown:
         case UIInterfaceOrientationPortrait:
             // Going to Portrait mode
-            for (UIScrollView *scroll in [webView subviews]) { //we get the scrollview 
+            for (UIScrollView *scroll in [webView subviews]) { //we get the scrollview
                 // Make sure it really is a scroll view and reset the zoom scale.
                 if ([scroll respondsToSelector:@selector(setZoomScale:)]){
                     scroll.minimumZoomScale = scroll.minimumZoomScale/ratioAspect;
@@ -309,7 +310,7 @@ enum actionSheetButtonIndex {
             break;
         default:
             // Going to Landscape mode
-            for (UIScrollView *scroll in [webView subviews]) { //we get the scrollview 
+            for (UIScrollView *scroll in [webView subviews]) { //we get the scrollview
                 // Make sure it really is a scroll view and reset the zoom scale.
                 if ([scroll respondsToSelector:@selector(setZoomScale:)]){
                     scroll.minimumZoomScale = scroll.minimumZoomScale *ratioAspect;
@@ -453,6 +454,11 @@ enum actionSheetButtonIndex {
 		{
             if (domainLockList == nil || [domainLockList isEqualToString:@""])
             {
+				if (navigationType == UIWebViewNavigationTypeLinkClicked)
+				{
+					currentURL = request.URL.absoluteString;
+				}
+                
                 return YES;
             }
             
@@ -468,7 +474,7 @@ enum actionSheetButtonIndex {
                         sendToSafari = NO;
                     }
                 }
-
+				
                 if (sendToSafari == YES)
                 {
                     [[UIApplication sharedApplication] openURL:[request URL]];
@@ -478,6 +484,11 @@ enum actionSheetButtonIndex {
                 
                 else
                 {
+					if (navigationType == UIWebViewNavigationTypeLinkClicked)
+					{
+						currentURL = request.URL.absoluteString;
+					}
+                    
                     return YES;
                 }
             }
@@ -511,7 +522,7 @@ enum actionSheetButtonIndex {
     if ([error code] == NSURLErrorCancelled) {
         return;
     }
-
+	
     // Show error alert
     UIAlertView *alert = [[UIAlertView alloc] initWithTitle:NSLocalizedString(@"Could not load page", nil)
                                                     message:error.localizedDescription


### PR DESCRIPTION
Specify a comma-separated list of URL prefixes, like @"http://seculartotem.com,http://jetpack.wordpress.com" and all non-matches will be opened in Mobile Safari automatically.
