### PR TITLE
Add storyboard support

### DIFF
--- a/TSMiniWebBrowser/TSMiniWebBrowser.m
+++ b/TSMiniWebBrowser/TSMiniWebBrowser.m
@@ -444,7 +444,11 @@ enum actionSheetButtonIndex {
 }
 
 - (void)loadURL:(NSURL*)url {
-    [webView loadRequest: [NSURLRequest requestWithURL: url]];
+    if (!webView) {
+        urlToLoad = url;
+        [self initWebView];
+    } else
+        [webView loadRequest: [NSURLRequest requestWithURL: url]];
 }
 
 #pragma mark - UIWebViewDelegate


### PR DESCRIPTION
Since View Controllers instantiated on a storyboard have `initWithCoder` called, I'm unable to use your designated initialiser.  This small addition allows me to work around this and use your mini web browser in a storyboard.
