### PR TITLE
Podspec & iOS 7 support

### DIFF
--- a/TSMiniWebBrowser.podspec
+++ b/TSMiniWebBrowser.podspec
@@ -1,0 +1,14 @@
+Pod::Spec.new do |s|
+  s.name         = 'TSMiniWebBrowser'
+  s.version      = '1.0.1'
+  s.platform     = :ios
+  s.license      = 'MIT'
+  s.summary      = 'An in-app web browser control for iOS apps.'
+  s.homepage     = 'https://github.com/pyro2927/TSMiniWebBrowser'
+  s.author       = { 'Toni Sala' => 'tonisalae@gmail.com' }
+  s.source       = { :git => 'https://github.com/pyro2927/TSMiniWebBrowser.git', :branch => "master" }
+  s.source_files = 'TSMiniWebBrowser/*.{h,m}'
+  s.framework    = 'QuartzCore'
+  s.requires_arc = true
+  s.resources    = 'TSMiniWebBrowser/images/*.png', 'TSMiniWebBrowser/*.xib'
+end

--- a/TSMiniWebBrowser.podspec
+++ b/TSMiniWebBrowser.podspec
@@ -4,9 +4,9 @@ Pod::Spec.new do |s|
   s.platform     = :ios
   s.license      = 'MIT'
   s.summary      = 'An in-app web browser control for iOS apps.'
-  s.homepage     = 'https://github.com/pyro2927/TSMiniWebBrowser'
+  s.homepage     = 'https://github.com/tonisalae/TSMiniWebBrowser'
   s.author       = { 'Toni Sala' => 'tonisalae@gmail.com' }
-  s.source       = { :git => 'https://github.com/pyro2927/TSMiniWebBrowser.git', :branch => "master" }
+  s.source       = { :git => 'https://github.com/tonisalae/TSMiniWebBrowser.git', :branch => "master" }
   s.source_files = 'TSMiniWebBrowser/*.{h,m}'
   s.framework    = 'QuartzCore'
   s.requires_arc = true

--- a/TSMiniWebBrowser/TSMiniWebBrowser.m
+++ b/TSMiniWebBrowser/TSMiniWebBrowser.m
@@ -180,13 +180,16 @@ enum actionSheetButtonIndex {
     if (mode == TSMiniWebBrowserModeModal) {
         webView = [[UIWebView alloc] initWithFrame:CGRectMake(0, kToolBarHeight, viewSize.width, viewSize.height-kToolBarHeight*2)];
     } else if(mode == TSMiniWebBrowserModeNavigation) {
-        webView = [[UIWebView alloc] initWithFrame:CGRectMake(0, 0, viewSize.width, viewSize.height-kToolBarHeight)];
+        webView = [[UIWebView alloc] initWithFrame:CGRectMake(0, 0, viewSize.width, viewSize.height)];
+        [[webView scrollView] setContentInset:UIEdgeInsetsMake(64, 0, 44, 0)];
+        [[webView scrollView] setScrollIndicatorInsets:UIEdgeInsetsMake(64, 0, 44, 0)];
     } else if(mode == TSMiniWebBrowserModeTabBar) {
         self.view.backgroundColor = [UIColor redColor];
         webView = [[UIWebView alloc] initWithFrame:CGRectMake(0, kToolBarHeight-1, viewSize.width, viewSize.height-kToolBarHeight+1)];
     }
     webView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
     [self.view addSubview:webView];
+    [self.view bringSubviewToFront:toolBar];
     
     webView.scalesPageToFit = YES;
     
@@ -215,6 +218,7 @@ enum actionSheetButtonIndex {
         forcedTitleBarText = nil;
         barStyle = UIBarStyleDefault;
 		barTintColor = nil;
+        self.automaticallyAdjustsScrollViewInsets = NO;
     }
     
     return self;

--- a/TSMiniWebBrowser/TSMiniWebBrowser.m
+++ b/TSMiniWebBrowser/TSMiniWebBrowser.m
@@ -181,8 +181,9 @@ enum actionSheetButtonIndex {
         webView = [[UIWebView alloc] initWithFrame:CGRectMake(0, kToolBarHeight, viewSize.width, viewSize.height-kToolBarHeight*2)];
     } else if(mode == TSMiniWebBrowserModeNavigation) {
         webView = [[UIWebView alloc] initWithFrame:CGRectMake(0, 0, viewSize.width, viewSize.height)];
-        [[webView scrollView] setContentInset:UIEdgeInsetsMake(64, 0, 44, 0)];
-        [[webView scrollView] setScrollIndicatorInsets:UIEdgeInsetsMake(64, 0, 44, 0)];
+        bool translucentNavBar = self.navigationController.navigationBar.isTranslucent;
+        [[webView scrollView] setContentInset:UIEdgeInsetsMake((translucentNavBar ? 64 : 0), 0, 44, 0)];
+        [[webView scrollView] setScrollIndicatorInsets:UIEdgeInsetsMake((translucentNavBar ? 64 : 0), 0, 44, 0)];
     } else if(mode == TSMiniWebBrowserModeTabBar) {
         self.view.backgroundColor = [UIColor redColor];
         webView = [[UIWebView alloc] initWithFrame:CGRectMake(0, kToolBarHeight-1, viewSize.width, viewSize.height-kToolBarHeight+1)];

--- a/TSMiniWebBrowser/TSMiniWebBrowser.m
+++ b/TSMiniWebBrowser/TSMiniWebBrowser.m
@@ -462,8 +462,8 @@ enum actionSheetButtonIndex {
 	else
 	{
 		if ([[request.URL absoluteString] hasPrefix:@"http://www.youtube.com/v/"] ||
-			[[request.URL absoluteString] hasPrefix:@"http://itunes.apple.com/"] ||
-			[[request.URL absoluteString] hasPrefix:@"http://phobos.apple.com/"]) {
+			[[request.URL host] isEqualToString:@"itunes.apple.com"] ||
+			[[request.URL host] isEqualToString:@"phobos.apple.com"]) {
 			[[UIApplication sharedApplication] openURL:request.URL];
 			return NO;
 		}


### PR DESCRIPTION
Adding in a podspec.  Fixing content edge insets for iOS7.  Changing host request checks to the domain instead of string prefix, as Apple is using `https://itunes.apple.com/` more than `http://itunes.apple.com/` now.
